### PR TITLE
fix/add -darker,-lighter colors to text color

### DIFF
--- a/colors/_ui-colors.yml
+++ b/colors/_ui-colors.yml
@@ -114,10 +114,12 @@ props:
   - name: color-action-darkest
     value: "#30855C"
     group: action
+    text: true
 
   - name: color-action-darker
     value: "#399E6E"
     group: action
+    text: true
 
   - name: color-action
     value: "#3DA774"
@@ -127,19 +129,23 @@ props:
   - name: color-action-lighter
     value: "#49B88B"
     group: action
+    text: true
 
   - name: color-action-lightest
     value: "#EBF6F1"
     group: action
+    text: true
     labelColor: dark
 
   - name: color-selected-darkest
     value: "#0A7DAF"
     group: selected
+    text: true
 
   - name: color-selected-darker
     value: "#0D94CF"
     group: selected
+    text: true
 
   - name: color-selected
     value: "#0D9DDB"
@@ -149,19 +155,23 @@ props:
   - name: color-selected-lighter
     value: "#0FB0E2"
     group: selected
+    text: true
 
   - name: color-selected-lightest
     value: "#E7F5FB"
     group: selected
     labelColor: dark
+    text: true
 
   - name: color-error-darkest
     value: "#B43931"
     group: error
+    text: true
 
   - name: color-error-darker
     value: "#D5443A"
     group: error
+    text: true
 
   - name: color-error
     value: "#E1483E"
@@ -171,19 +181,23 @@ props:
   - name: color-error-lighter
     value: "#E7564A"
     group: error
+    text: true
 
   - name: color-error-lightest
     value: "#FBECEB"
     group: error
     labelColor: dark
+    text: true
 
   - name: color-warning-darkest
     value: "#CC900D"
     group: warning
+    text: true
 
   - name: color-warning-darker
     value: "#F2AB10"
     group: warning
+    text: true
 
   - name: color-warning
     value: "#FFB511"
@@ -193,11 +207,13 @@ props:
   - name: color-warning-lighter
     value: "#FFC314"
     group: warning
+    text: true
 
   - name: color-warning-lightest
     value: "#FFF7E7"
     group: warning
     labelColor: dark
+    text: true
 
   - name: color-secondary-darker
     value: "#E0E5E8"


### PR DESCRIPTION
### text with $color-warning #FFB511
![Screen Shot 2019-07-17 at 11 29 57 AM](https://user-images.githubusercontent.com/19500312/61391179-27e84f00-a88a-11e9-8786-abd801e07f19.png)

### text with $color-warning-darkest #CC900D
https://www.bgov.com/core/opportunity_search#/
Click `Add to Project` on the card.
If the selected folder already contains selected bill, it'll show up 
![Screen Shot 2019-07-17 at 11 03 19 AM](https://user-images.githubusercontent.com/19500312/61391277-5fef9200-a88a-11e9-9f78-65f5eee7ceb2.png)

`FishTankText` component does not support -darker, -darkest, -lighter, -lightest colors as a text prop.

Please add them to text colors,
or consider updating the color hex code to have a better contrast ratio.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
